### PR TITLE
[Fix] - "^" in regex di "STCausaleVersamento"

### DIFF
--- a/psp/sac-common-types-1.0.xsd
+++ b/psp/sac-common-types-1.0.xsd
@@ -36,7 +36,7 @@
 
 	 <xsd:simpleType name="stCausaleVersamento">
         <xsd:restriction base="xsd:string">
-            <xsd:pattern value="(^\/RFB|^\/RFS)(\/[0-9a-zA-Z]{13,35})(\/\d+\.\d{2})?((\/TXT)(\/.{1,140})|)?"/>
+            <xsd:pattern value="(\/RFB|\/RFS)(\/[0-9a-zA-Z]{13,35})(\/\d+\.\d{2})?((\/TXT)(\/.{1,140})|)?"/>
             <xsd:maxLength value="140"/>
         </xsd:restriction>
     </xsd:simpleType>


### PR DESCRIPTION
In stCausaleVersamento rimosso carattere "^" dalla regex in quanto, secondo specifiche W3C [https://www.w3.org/TR/xmlschema11-2/#regexs] quel carattere su xsd non identifica un carattere speciale ma proprio il carattere "^" (questo avviene perchè in xsd il riconoscimento definite vengono sempre e comunque identificate tra testa e coda ed i caratteri speciali "^" e "$" non sono quindi utilizzati).