### PR TITLE
Feature/pagopa 381 revert fix dependencies

### DIFF
--- a/ec/PagInf_RPT_RT_6_2_0.xsd
+++ b/ec/PagInf_RPT_RT_6_2_0.xsd
@@ -823,6 +823,11 @@
 					<xsd:documentation>Campo numerico (due cifre per la parte decimale, il separatore dei centesimi è il punto "."), indicante l’importo della commissione applicata dal PSP al proprio cliente (soggetto versante o soggetto pagatore).</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="commissioniApplicatePA" type="pay_i:stImportoDiversoDaZero" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Campo numerico (due cifre per la parte decimale, il separatore dei centesimi è il punto "."), indicante l’importo della commissione applicata dalla PA a fronte di una convezione.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="allegatoRicevuta" type="pay_i:ctAllegatoRicevuta" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Aggregazione contenente l'allegato al singolo pagamento.</xsd:documentation>

--- a/ec/PagInf_RPT_RT_6_2_0.xsd
+++ b/ec/PagInf_RPT_RT_6_2_0.xsd
@@ -2,7 +2,6 @@
 <xsd:schema
 		xmlns:pay_i="http://www.digitpa.gov.it/schemas/2011/Pagamenti/"
 		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-		xmlns:sac="http://ws.pagamenti.telematici.gov/"
 		targetNamespace="http://www.digitpa.gov.it/schemas/2011/Pagamenti/"
 		elementFormDefault="qualified"
 		attributeFormDefault="unqualified"
@@ -14,7 +13,6 @@
 		<xsd:documentation>= 28/02/2018 - allineamento a versione 2.1 dell'Allegato B</xsd:documentation>
 	</xsd:annotation>
 
-	<xsd:import  schemaLocation="sac-common-types-1.0.xsd" namespace="http://ws.pagamenti.telematici.gov/"/>
 	<!-- **** BEGIN: tipi semplici  ****-->
 
 	<xsd:simpleType name="stISODate">

--- a/general/PagInf_RPT_RT_6_2_0.xsd
+++ b/general/PagInf_RPT_RT_6_2_0.xsd
@@ -2,7 +2,6 @@
 <xsd:schema
 		xmlns:pay_i="http://www.digitpa.gov.it/schemas/2011/Pagamenti/"
 		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-		xmlns:sac="http://ws.pagamenti.telematici.gov/"
 		targetNamespace="http://www.digitpa.gov.it/schemas/2011/Pagamenti/"
 		elementFormDefault="qualified"
 		attributeFormDefault="unqualified"
@@ -14,7 +13,6 @@
 		<xsd:documentation>= 28/02/2018 - allineamento a versione 2.1 dell'Allegato B</xsd:documentation>
 	</xsd:annotation>
 
-	<xsd:import  schemaLocation="sac-common-types-1.0.xsd" namespace="http://ws.pagamenti.telematici.gov/"/>
 	<!-- **** BEGIN: tipi semplici  ****-->
 
 	<xsd:simpleType name="stISODate">

--- a/nodo/PagInf_RPT_RT_6_2_0.xsd
+++ b/nodo/PagInf_RPT_RT_6_2_0.xsd
@@ -823,6 +823,11 @@
 					<xsd:documentation>Campo numerico (due cifre per la parte decimale, il separatore dei centesimi è il punto "."), indicante l’importo della commissione applicata dal PSP al proprio cliente (soggetto versante o soggetto pagatore).</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="commissioniApplicatePA" type="pay_i:stImportoDiversoDaZero" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Campo numerico (due cifre per la parte decimale, il separatore dei centesimi è il punto "."), indicante l’importo della commissione applicata dalla PA a fronte di una convezione.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="allegatoRicevuta" type="pay_i:ctAllegatoRicevuta" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>Aggregazione contenente l'allegato al singolo pagamento.</xsd:documentation>

--- a/nodo/PagInf_RPT_RT_6_2_0.xsd
+++ b/nodo/PagInf_RPT_RT_6_2_0.xsd
@@ -2,7 +2,6 @@
 <xsd:schema
 		xmlns:pay_i="http://www.digitpa.gov.it/schemas/2011/Pagamenti/"
 		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-		xmlns:sac="http://ws.pagamenti.telematici.gov/"
 		targetNamespace="http://www.digitpa.gov.it/schemas/2011/Pagamenti/"
 		elementFormDefault="qualified"
 		attributeFormDefault="unqualified"


### PR DESCRIPTION
Removed unused imports of "sac-common-types" xsd and corresponding namespace
Added missing "commissioniApplicatePA" element