### PR TITLE
[PAG-981] add github action auto PR

### DIFF
--- a/.github/workflow/auto_pr.yaml
+++ b/.github/workflow/auto_pr.yaml
@@ -1,0 +1,19 @@
+name: Pull Request Action
+on:
+  push:
+    branches:
+      - feature/*
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: pull-request
+        uses: repo-sync/pull-request@v2
+        with:
+          destination_branch: "develop"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_label: "auto-align-wsdl"
+          pr_title: "[Align WSDL-XSD] auto-align-wsdl"


### PR DESCRIPTION
The purpose of this PR is to add auto PR github action on push new branch.

- on every push made on `develop` branch of https://github.com/pagopa/pagopa-nodo4-nodo-dei-pagamenti
- starting a github action the build nodo4 ( to check if is all right, wsdl/xsd too ) 
- find all wsdl/xsd differences
- create a new brach on pagopa-api repo with name `feature/auto-align-wsdl-<UUID>` starting from `develop`
- push this branch

after that a newone github action ( on local repo ) 
- create from previously  branch e new auto PR 
 