### PR TITLE
add UAT host environment

### DIFF
--- a/api/checkout.yaml
+++ b/api/checkout.yaml
@@ -4,10 +4,15 @@ info:
   title: pagoPA checkout-EC API
   contact:
     name: pagoPA checkout team
-    url: https://portal.uat.platform.pagopa.it
+    url: https://portal.platform.pagopa.it
+  # contact for UAT environment
+  #  contact:
+  #  name: pagoPA checkout team
+  #  url: https://portal.platform.pagopa.it
   description: |
     Documentation of the pagoPA checkout API here.
 host: api.platform.pagopa.it
+# UAT host: api.uat.platform.pagopa.it
 basePath: /checkout/v1
 schemes:
   - https


### PR DESCRIPTION
This PR should defines HOSTNAME for UAT environment.
Since, OpenAPI 2 not support multiple hostname, UAT hostname has been added as comment 