### PR TITLE
fix: typo

### DIFF
--- a/api/checkout.yaml
+++ b/api/checkout.yaml
@@ -144,7 +144,7 @@ definitions:
             type: string
             format: uri
             example: "www.comune.di.prova.it/pagopa/cancel.html"
-          retunErrorUrl:
+          returnErrorUrl:
             type: string
             format: uri
             example: "www.comune.di.prova.it/pagopa/error.html"


### PR DESCRIPTION
### Description

The goal of this PR is to fix a simple typo for `checkout.yaml`