### PR TITLE
Fix payment notice

### DIFF
--- a/openapi/checkout.yaml
+++ b/openapi/checkout.yaml
@@ -148,7 +148,7 @@ components:
           required:
             - returnOkUrl
             - returnCancelUrl
-            - retunErrorUrl
+            - retunrErrorUrl
           properties:
             returnOkUrl:
               type: string
@@ -158,7 +158,7 @@ components:
               type: string
               format: uri
               example: www.comune.di.prova.it/pagopa/cancel.html
-            returnErrorUrl:
+            retunrErrorUrl:
               type: string
               format: uri
               example: www.comune.di.prova.it/pagopa/error.html

--- a/openapi/checkout.yaml
+++ b/openapi/checkout.yaml
@@ -164,6 +164,12 @@ components:
               example: www.comune.di.prova.it/pagopa/error.html
     PaymentNotice:
       type: object
+      required:
+        - noticeNumber
+        - fiscalCode
+        - amount
+        - companyName
+        - description
       properties:
         noticeNumber:
           type: string

--- a/openapi/checkout.yaml
+++ b/openapi/checkout.yaml
@@ -140,9 +140,15 @@ components:
           maxItems: 5
           example:
             - noticeNumber: "302012387654312384"
-              fiscalCode: "7777777777"
+              fiscalCode: "77777777777"
+              amount: 10000
+              companyName: "companyName"
+              description: "description"
             - noticeNumber: "302012387654312385"
-              fiscalCode: "7777777777"
+              fiscalCode: "77777777777"
+              amount: 5000
+              companyName: "companyName"
+              description: "description"
         returnUrls:
           type: object
           required:

--- a/openapi/checkout.yaml
+++ b/openapi/checkout.yaml
@@ -148,7 +148,7 @@ components:
           required:
             - returnOkUrl
             - returnCancelUrl
-            - retunrErrorUrl
+            - returnErrorUrl
           properties:
             returnOkUrl:
               type: string
@@ -158,7 +158,7 @@ components:
               type: string
               format: uri
               example: www.comune.di.prova.it/pagopa/cancel.html
-            retunrErrorUrl:
+            returnErrorUrl:
               type: string
               format: uri
               example: www.comune.di.prova.it/pagopa/error.html

--- a/openapi/checkout.yaml
+++ b/openapi/checkout.yaml
@@ -172,20 +172,25 @@ components:
         - description
       properties:
         noticeNumber:
+          description: notice number 
           type: string
           minLength: 18
           maxLength: 18
         fiscalCode:
+          description: Public Administration tax code
           type: string
           minLength: 11
           maxLength: 11
         amount:
+          description: amount ( in euro cents ) of the payment notice  
           type: integer
           minimum: 1
         companyName:
+          description: Public Administration company name
           type: string
           maxLength: 140
         description:
+          description: subject of payment 
           type: string
           maxLength: 140
     CartResponse:


### PR DESCRIPTION
Any properties of the Payment Notice object is optional.

In order to be able to continue to the payment noticeNumber, fiscal_code are needed.
In order to improve UX amount,companyname and description are needed.

SANP should be updated too