### PR TITLE
Parametri obbligatori nella GetIdResponse

### DIFF
--- a/openapi/fdr.yaml
+++ b/openapi/fdr.yaml
@@ -7,7 +7,7 @@ info:
   termsOfService: https://www.pagopa.gov.it/
   version: 1.0.0-SNAPSHOT
 servers:
-  - url:https://api.uat.platform.pagopa.it/fdr/service/v1
+  - url: https://api.uat.platform.pagopa.it/fdr/service/v1
 tags:
   - name: Info
     description: Info operations

--- a/openapi/fdr.yaml
+++ b/openapi/fdr.yaml
@@ -487,6 +487,16 @@ components:
             $ref: '#/components/schemas/Flow'
     GetIdResponse:
       type: object
+      required: 
+        - created
+        - reportingFlowName
+        - reportingFlowDate
+        - sender
+        - receiver
+        - regulation
+        - regulationDate
+        - totPayments
+        - sumPayments
       properties:
         status:
           type: string


### PR DESCRIPTION
Aggiunto uno spazio nel `server.url` a separazione del valore: l'assenza creava problemi con lo SwaggerEditor.

Proposti i parametri obbligatori alla GetIdResponse: indicati quelli già obbligatori per i PSP in sede di pubblicazione più `created`, `totPayments` e `sumPayments`