### PR TITLE
feat: [SANP3.12.0] print_notice_404

### DIFF
--- a/openapi/print-payment-notice-service.json
+++ b/openapi/print-payment-notice-service.json
@@ -888,6 +888,17 @@
               }
             }
           },
+          "404": {
+            "description": "Institution Not Found",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Too many requests",
             "headers": {


### PR DESCRIPTION
depends on https://github.com/pagopa/pagopa-print-payment-notice-generator/pull/33 for coherence
depends on https://github.com/pagopa/pagopa-print-payment-notice-service/pull/78 for coherence
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- added 404 response to /notices/generate
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This is required to make the documentation consistent after the changes made on the services above

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- tested on swagger editor <br>
<img width="1298" height="206" alt="image" src="https://github.com/user-attachments/assets/473c18f3-3145-4a46-8733-daae78220e04" /> <br>

- TODO test if DevPortal shows the 404 as documented for the /notices/generate API

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
