### PR TITLE
fix: fixed fdr psp wrong url

### DIFF
--- a/openapi/fdr_psp.json
+++ b/openapi/fdr_psp.json
@@ -8,7 +8,7 @@
   },
   "servers": [
     {
-      "url": "https://api.platform.pagopa.it/fdr-psp/service/v1"
+      "url": "https://api.uat.platform.pagopa.it/fdr-psp/service/v1"
     }
   ],
   "paths": {


### PR DESCRIPTION
Fixed fdr URL that was poiting to prod ENV